### PR TITLE
Fix sign error in BigInt::leftShift.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -313,9 +313,7 @@ emu-integration-plans:before {
       <h1>BigInt::leftShift (_x_, _y_)</h1>
       <p>The abstract operation BigInt::leftShift with two arguments _x_ and _y_ of BigInt:</p>
       <emu-alg>
-        1. If _y_ &lt; 0,
-          1. Return a BigInt representing _x_ divided by 2<sup>_y_</sup>, rounding down to the nearest integer, including for negative numbers.
-        1. Return a BigInt representing _x_ multiplied by 2<sup>_y_</sup>.
+        1. Return a BigInt representing _x_ multiplied by 2<sup>_y_</sup>, rounding down to the nearest integer, including for negative numbers.
       </emu-alg>
       <emu-note>Semantics here should be equivalent to a bitwise shift, treating the BigInt as an infinite length string of binary two's complement digits.</emu-note>
     </emu-clause>
@@ -324,7 +322,7 @@ emu-integration-plans:before {
       <h1>BigInt::signedRightShift (_x_, _y_)</h1>
       <p>The abstract operation BigInt::signedRightShift with arguments _x_ and _y_ of type BigInt:</p>
       <emu-alg>
-        1. Return ? BigInt::leftShift(_x_, -_y_).
+        1. Return BigInt::leftShift(_x_, -_y_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
If y is negative, we need to divide by 2^(-y), i.e., multiply by 2^y.