### PR TITLE
Normative: Restore the IsSafeInteger check in BigInt()

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1251,7 +1251,9 @@ emu-integration-plans:before {
         <p>When `BigInt` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
-          1. Return ? ForceToBigInt(_value_).
+          1. Let _prim_ be ? ToPrimitive(_value_, hint Number).
+          1. If Type(_prim_) is Number, return ? NumberToBigInt(_prim_).
+          1. Otherwise, return ? ToBigInt(_value_).
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
When converting a Number to a BigInt in the BigInt constructor,
the Number is checked for whether it is a "safe integer". If it is
not, an exception is thrown. This logic was decided on in the
conclusion to https://github.com/tc39/proposal-bigint/issues/15 .

This typo was made in a previous patch due to a refactoring to
share a common path, which wasn't undone when that other path
removed the IsSafeInteger check (over the evolution of the PR).

Thanks to @jakobkummerow for catching the issue.

Closes #110 