### PR TITLE
Revert "Normative: Restore the IsSafeInteger check in BigInt()"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1251,9 +1251,7 @@ emu-integration-plans:before {
         <p>When `BigInt` is called with argument _value_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
-          1. Let _prim_ be ? ToPrimitive(_value_, hint Number).
-          1. If Type(_prim_) is Number, return ? NumberToBigInt(_prim_).
-          1. Otherwise, return ? ToBigInt(_value_).
+          1. Return ? ForceToBigInt(_value_).
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
Reverts tc39/proposal-bigint#111

Rolling back patches for TC39 consensus to remove implicit conversions on TypedArray Set.