### PR TITLE
Normative: Permit BigInt(large Number)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1214,24 +1214,22 @@ emu-integration-plans:before {
       <h1>The BigInt Constructor</h1>
       <p>The BigInt constructor is the <dfn>%BigInt%</dfn> intrinsic object and the initial value of the `BigInt` property of the global object. When `BigInt` is called as a function, it performs a type conversion.</p>
 
-      <emu-clause id="sec-is-safe-integer" aoid="IsSafeInteger">
-        <h1>IsSafeInteger ( _number_ )</h1>
+      <emu-clause id="sec-is-integer" aoid="IsInteger">
+        <h1>IsInteger ( _number_ )</h1>
         <emu-alg>
           1. Assert: Type(_number_) is Number.
           1. If _number_ is *NaN*, *+&infin;*, or *-&infin;*, return *false*.
           1. Let _integer_ be ! ToInteger(_number_).
           1. If ! SameValueZero(_integer_, _number_) is *false*, return *false*.
-          1. If abs(_integer_) &le; 2<sup>53</sup>-1, return *true*.
-          1. Otherwise, return *false*.
+          1. Otherwise, return *true*.
         </emu-alg>
-        <emu-integration-plans>Number.isSafeInteger will be refactored to call this abstract algorithm.</emu-integration-plans>
       </emu-clause>
 
       <emu-clause id="sec-number-to-bigint" aoid="NumberToBigInt">
         <h1>NumberToBigInt ( _number_ )</h1>
         <emu-alg>
           1. Assert: Type(_number_) is Number.
-          1. If IsSafeInteger(_number_) is *false*, throw a *RangeError* exception.
+          1. If IsInteger(_number_) is *false*, throw a *RangeError* exception.
           1. Return a BigInt representing the mathematical value of _number_.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Previously, the BigInt constructor used IsSafeInteger to check if a Number
is safe to cast to a BigInt without losing information. This check is
unnecessarily conservative--it rules out large integer-valued Numbers.
This patch switches to just check that the Number is an integer value.

This patch specifies the resolution of the discussion in the March
2018 TC39 meeting.

Closes #132